### PR TITLE
Fix indention rule

### DIFF
--- a/OpaySniffs/ruleset.xml
+++ b/OpaySniffs/ruleset.xml
@@ -9,6 +9,7 @@
         <properties>
             <property name="ignoreIndentationTokens" type="array">
                 <element value="T_COMMENT"/>
+                <element value="T_CASE"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
- Disable `case` indent validation for `PEAR.WhiteSpace.ScopeIndent` rule