### PR TITLE
lock php-cs-fixer version to 3.77.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.81",
+        "friendsofphp/php-cs-fixer": "3.77.0",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "3.73.1",
+        "friendsofphp/php-cs-fixer": "3.77.0",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.80",
+        "friendsofphp/php-cs-fixer": "3.75.0",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "3.75.0",
+        "friendsofphp/php-cs-fixer": "3.73.1",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "3.77.0",
+        "friendsofphp/php-cs-fixer": "^3.81",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.75",
+        "friendsofphp/php-cs-fixer": "^3.80",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"


### PR DESCRIPTION
## Description

From 3.78.0 to latest version there problem that fixed does not recognize `readonly` and creates error that  visibility required
![image](https://github.com/user-attachments/assets/ebafa2a7-3136-466f-ae23-8a4d6e0c3b1c)

![image](https://github.com/user-attachments/assets/65862f54-a387-40c5-bfb0-ab66da84bce0)


## Type of change
- [ ] __New feature__ (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected)
- [ ] __Bug fix__ (non-breaking change which fixes an issue)
- [ ] __Tech. debt__ (non-breaking code improvement or technical functionality)

## Code testing
- [ ] Manual testing done

## Code quality
- [ ] My changes generate no new warnings or errors in IDE
- [ ] I have performed a self-review of my own code before selecting reviewers
- [ ] My code does not smell (I am sure about my code quality, I did the best I could)
