### PR TITLE
APP-100: Replace PHP Linting Tools PHP_CS_FIXER_IGNORE_ENV config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.84",
+        "friendsofphp/php-cs-fixer": "^3.75",
         "moxio/php-codesniffer-sniffs": "^2.6",
-        "slevomat/coding-standard": "^8.19",
+        "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.75",
+        "friendsofphp/php-cs-fixer": "^3.84",
         "moxio/php-codesniffer-sniffs": "^2.6",
-        "slevomat/coding-standard": "^8.15",
+        "slevomat/coding-standard": "^8.19",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {

--- a/lint
+++ b/lint
@@ -2,22 +2,22 @@
 
 if [ -z "$1" ]; then
 
-    vendor/bin/php-cs-fixer fix . --dry-run --verbose
+    vendor/bin/php-cs-fixer fix . --dry-run --verbose --allow-unsupported-php-version=yes
     vendor/bin/phpcs -p --standard=OpaySniffs . --ignore=./vendor
 
 elif [ "$1" == "fix" ]; then
 
-    vendor/bin/php-cs-fixer fix . --verbose
+    vendor/bin/php-cs-fixer fix . --verbose --allow-unsupported-php-version=yes
     vendor/bin/phpcbf -p --standard=OpaySniffs . --ignore=./vendor
 
 elif [ "$1" == "--custom" ] && [ -z "$2" ]; then
 
-    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --dry-run --verbose
+    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --dry-run --verbose --allow-unsupported-php-version=yes
     vendor/bin/phpcs -p --standard="Examples/custom_phpcs_config.xml"
 
 elif [ "$1" == "--custom" ] && [ "$2" == "fix" ]; then
 
-    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --verbose
+    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --verbose --allow-unsupported-php-version=yes
     vendor/bin/phpcbf -p --standard="Examples/custom_phpcs_config.xml"
 
 else


### PR DESCRIPTION
## Description

_Added `--allow-unsupported-php-version=yes` config when running `php-cs-fixer`. This is step 1 of this task. PHP_CS_FIXER_IGNORE_ENV must be removed from docker-compose.yml of each app_

## Type of change
- [ ] __New feature__ (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected)
- [ ] __Bug fix__ (non-breaking change which fixes an issue)
- [x] __Tech. debt__ (non-breaking code improvement or technical functionality)

## Code testing
- [x] Manual testing done

## Code quality
- [x] My changes generate no new warnings or errors in IDE
- [x] I have performed a self-review of my own code before selecting reviewers
- [x] My code does not smell (I am sure about my code quality, I did the best I could)
