### PR TITLE
Upgrade to PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1.0
+          php-version: 8.5.0
           extensions: json, pdo
           coverage: none
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 composer.lock
 .php-cs-fixer.cache
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+start up:
+	docker-compose up -d
+
+stop down:
+	docker-compose down
+
+list:
+	docker-compose ps
+
+list-all:
+	docker ps -a
+
+# Exec containers
+enter php exec exec-app:
+	docker-compose exec linting_tools sh
+
+# Logs
+log logs:
+	docker-compose logs linting_tools
+
+tail follow:
+	docker-compose logs --follow linting_tools

--- a/OpaySniffs/Sniffs/Classes/ForbiddenClassesSniff.php
+++ b/OpaySniffs/Sniffs/Classes/ForbiddenClassesSniff.php
@@ -25,7 +25,6 @@ use SlevomatCodingStandard\Helpers\UseStatementHelper;
  */
 class ForbiddenClassesSniff implements Sniff
 {
-
     public const CODE_FORBIDDEN_CLASS = 'ForbiddenClass';
     public const CODE_FORBIDDEN_PARENT_CLASS = 'ForbiddenParentClass';
     public const CODE_FORBIDDEN_INTERFACE = 'ForbiddenInterface';
@@ -77,6 +76,7 @@ class ForbiddenClassesSniff implements Sniff
         return $searchTokens;
     }
 
+    // phpcs:ignore SlevomatCodingStandard.Functions.FunctionLength
     public function process(File $phpcsFile, int $tokenPointer): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -127,6 +127,7 @@ class ForbiddenClassesSniff implements Sniff
         }
     }
 
+    // phpcs:ignore SlevomatCodingStandard.Functions.FunctionLength
     private function checkReferences(
         File $phpcsFile,
         int $tokenPointer,
@@ -203,6 +204,7 @@ class ForbiddenClassesSniff implements Sniff
                 $reference['pointer'],
                 $code,
             );
+
             if (!$fix) {
                 continue;
             }
@@ -247,6 +249,7 @@ class ForbiddenClassesSniff implements Sniff
 
             if (in_array($tokens[$referencePointer]['code'], TokenHelper::CLASS_KEYWORD_CODES, true)) {
                 $startPointer = $referencePointer + 1;
+
                 continue;
             }
 
@@ -282,9 +285,9 @@ class ForbiddenClassesSniff implements Sniff
         return $forbiddenClasses;
     }
 
-    private static function normalizeClassName(?string $typeName): ?string
+    private static function normalizeClassName(string|null $typeName): string|null
     {
-        if ($typeName === null || strlen($typeName) === 0 || strtolower($typeName) === 'null') {
+        if ($typeName === null || $typeName === '' || strtolower($typeName) === 'null') {
             return null;
         }
 
@@ -295,7 +298,7 @@ class ForbiddenClassesSniff implements Sniff
     {
         $alternativesString = str_replace(' ', '', $alternativesString);
         $alternatives = explode(',', $alternativesString);
-        $alternatives = array_map(static fn($alt) => self::normalizeClassName($alt), array_filter($alternatives));
+        $alternatives = array_map(static fn ($alt) => self::normalizeClassName($alt), array_filter($alternatives));
 
         return array_merge([''], $alternatives);
     }

--- a/OpaySniffs/Sniffs/Classes/ForbiddenClassesSniff.php
+++ b/OpaySniffs/Sniffs/Classes/ForbiddenClassesSniff.php
@@ -8,16 +8,15 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\FixerHelper;
 use SlevomatCodingStandard\Helpers\NamespaceHelper;
-use SlevomatCodingStandard\Helpers\ReferencedNameHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\UseStatementHelper;
 
 /**
- * This is duplicate of SlevomatCodingStandard.PHP.ForbiddenClasses
+ * This is a duplicate of SlevomatCodingStandard.PHP.ForbiddenClasses
  *
  * It does not fix error if alternative namespace does not exist and formats more informative error when several
  * alternatives exist. This "fix" allows specifying more than one alternative separating it with comma.
- * Everything else works identical to original sniff.
+ * Everything else works identical to the original sniff.
  *
  * Example:
  *  <element key="Old\Class" value="Alternative\One, Alternative\Two"/>
@@ -26,16 +25,25 @@ use SlevomatCodingStandard\Helpers\UseStatementHelper;
  */
 class ForbiddenClassesSniff implements Sniff
 {
+
     public const CODE_FORBIDDEN_CLASS = 'ForbiddenClass';
     public const CODE_FORBIDDEN_PARENT_CLASS = 'ForbiddenParentClass';
     public const CODE_FORBIDDEN_INTERFACE = 'ForbiddenInterface';
     public const CODE_FORBIDDEN_TRAIT = 'ForbiddenTrait';
 
+    /** @var array<string, (string|null)> */
     public array $forbiddenClasses = [];
+
+    /** @var array<string, (string|null)> */
     public array $forbiddenExtends = [];
+
+    /** @var array<string, (string|null)> */
     public array $forbiddenInterfaces = [];
+
+    /** @var array<string, (string|null)> */
     public array $forbiddenTraits = [];
 
+    /** @var list<string> */
     private static array $keywordReferences = ['self', 'parent', 'static'];
 
     /**
@@ -69,89 +77,64 @@ class ForbiddenClassesSniff implements Sniff
         return $searchTokens;
     }
 
-    public function process(File $phpcsFile, $stackPtr): void
+    public function process(File $phpcsFile, int $tokenPointer): void
     {
         $tokens = $phpcsFile->getTokens();
-        $token = $tokens[$stackPtr];
-        $nameTokens = array_merge(TokenHelper::getNameTokenCodes(), TokenHelper::$ineffectiveTokenCodes);
+        $token = $tokens[$tokenPointer];
+        $nameTokens = [...TokenHelper::NAME_TOKEN_CODES, ...TokenHelper::INEFFECTIVE_TOKEN_CODES];
 
         if (
             $token['code'] === T_IMPLEMENTS
-            || ($token['code'] === T_USE && UseStatementHelper::isTraitUse($phpcsFile, $stackPtr))
+            || (
+                $token['code'] === T_USE
+                && UseStatementHelper::isTraitUse($phpcsFile, $tokenPointer)
+            )
         ) {
-            $this->processImplementationOrTrait($phpcsFile, $stackPtr, $tokens);
+            $endTokenPointer = TokenHelper::findNext(
+                $phpcsFile,
+                [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
+                $tokenPointer,
+            );
+            $references = $this->getAllReferences($phpcsFile, $tokenPointer, $endTokenPointer);
 
-            return;
+            if ($token['code'] === T_IMPLEMENTS) {
+                $this->checkReferences($phpcsFile, $tokenPointer, $references, $this->forbiddenInterfaces);
+            } else {
+                // Fixer does not work when traits contains aliases
+                $this->checkReferences(
+                    $phpcsFile,
+                    $tokenPointer,
+                    $references,
+                    $this->forbiddenTraits,
+                    $tokens[$endTokenPointer]['code'] !== T_OPEN_CURLY_BRACKET,
+                );
+            }
+        } elseif (in_array($token['code'], [T_NEW, T_EXTENDS], true)) {
+            $endTokenPointer = TokenHelper::findNextExcluding($phpcsFile, $nameTokens, $tokenPointer + 1);
+            $references = $this->getAllReferences($phpcsFile, $tokenPointer, $endTokenPointer);
+
+            $this->checkReferences(
+                $phpcsFile,
+                $tokenPointer,
+                $references,
+                $token['code'] === T_NEW ? $this->forbiddenClasses : $this->forbiddenExtends,
+            );
+        } elseif ($token['code'] === T_DOUBLE_COLON && !$this->isTraitsConflictResolutionToken($token)) {
+            $startTokenPointer = TokenHelper::findPreviousExcluding($phpcsFile, $nameTokens, $tokenPointer - 1);
+            $references = $this->getAllReferences($phpcsFile, $startTokenPointer, $tokenPointer);
+
+            $this->checkReferences($phpcsFile, $tokenPointer, $references, $this->forbiddenClasses);
         }
-
-        if (in_array($token['code'], [T_NEW, T_EXTENDS], true)) {
-            $this->processInheritanceOrNew($phpcsFile, $stackPtr, $token, $nameTokens);
-
-            return;
-        }
-
-        // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit
-        if ($token['code'] === T_DOUBLE_COLON && !$this->isTraitsConflictResolutionToken($token)) {
-            $this->processDoubleColon($phpcsFile, $stackPtr, $nameTokens);
-        }
-    }
-
-    private function processImplementationOrTrait(File $phpcsFile, int|null $stackPtr, array $tokens): void
-    {
-        $token = $tokens[$stackPtr];
-
-        $endTokenPointer = TokenHelper::findNext(
-            $phpcsFile,
-            [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
-            $stackPtr
-        );
-        $references = $this->getAllReferences($phpcsFile, $stackPtr, $endTokenPointer);
-
-        if ($token['code'] === T_IMPLEMENTS) {
-            $this->checkReferences($phpcsFile, $stackPtr, $references, $this->forbiddenInterfaces);
-
-            return;
-        }
-
-        // Fixer does not work when traits contains aliases
-        $this->checkReferences(
-            $phpcsFile,
-            $stackPtr,
-            $references,
-            $this->forbiddenTraits,
-            $tokens[$endTokenPointer]['code'] !== T_OPEN_CURLY_BRACKET
-        );
-    }
-
-    private function processInheritanceOrNew(File $phpcsFile, int|null $stackPtr, array $token, array $nameTokens): void
-    {
-        $endTokenPointer = TokenHelper::findNextExcluding($phpcsFile, $nameTokens, $stackPtr + 1);
-        $references = $this->getAllReferences($phpcsFile, $stackPtr, $endTokenPointer);
-
-        $this->checkReferences(
-            $phpcsFile,
-            $stackPtr,
-            $references,
-            $token['code'] === T_NEW ? $this->forbiddenClasses : $this->forbiddenExtends
-        );
-    }
-
-    private function processDoubleColon(File $phpcsFile, int|null $stackPtr, array $nameTokens): void
-    {
-        $startTokenPointer = TokenHelper::findPreviousExcluding($phpcsFile, $nameTokens, $stackPtr - 1);
-        $references = $this->getAllReferences($phpcsFile, $startTokenPointer, $stackPtr);
-
-        $this->checkReferences($phpcsFile, $stackPtr, $references, $this->forbiddenClasses);
     }
 
     private function checkReferences(
         File $phpcsFile,
-        int $stackPtr,
+        int $tokenPointer,
         array $references,
         array $forbiddenNames,
         bool $isFixable = true
     ): void {
-        $token = $phpcsFile->getTokens()[$stackPtr];
+        $token = $phpcsFile->getTokens()[$tokenPointer];
         $details = [
             T_NEW => ['class', self::CODE_FORBIDDEN_CLASS],
             T_DOUBLE_COLON => ['class', self::CODE_FORBIDDEN_CLASS],
@@ -168,16 +151,67 @@ class ForbiddenClassesSniff implements Sniff
             $alternative = $forbiddenNames[$reference['fullyQualifiedName']];
             [$nameType, $code] = $details[$token['code']];
 
-            /*
-             * class_exists($alternative) === false - this was the point of original class copying
-             */
-            if ($alternative === null || $isFixable === false || class_exists($alternative) === false) {
-                $this->addErrorWithoutFixing($phpcsFile, $reference, $nameType, $alternative, $code);
+            if ($alternative === null) {
+                $phpcsFile->addError(
+                    sprintf('Usage of %s %s is forbidden.', $reference['fullyQualifiedName'], $nameType),
+                    $reference['pointer'],
+                    $code,
+                );
 
                 continue;
             }
 
-            $this->addErrorAndFix($phpcsFile, $reference, $nameType, $alternative, $code);
+            if (str_contains($alternative, ',') === true) {
+                $alts = $this->formatAlternativesArray($alternative);
+
+                $phpcsFile->addError(
+                    sprintf(
+                        'Usage of %s %s is forbidden, use one of these instead: %s',
+                        $reference['fullyQualifiedName'],
+                        $nameType,
+                        implode("\n   ", $alts)
+                    ),
+                    $reference['pointer'],
+                    $code,
+                );
+
+                continue;
+            }
+
+            if (!$isFixable) {
+                $phpcsFile->addError(
+                    sprintf(
+                        'Usage of %s %s is forbidden, use %s instead.',
+                        $reference['fullyQualifiedName'],
+                        $nameType,
+                        $alternative,
+                    ),
+                    $reference['pointer'],
+                    $code,
+                );
+
+                continue;
+            }
+
+            $fix = $phpcsFile->addFixableError(
+                sprintf(
+                    'Usage of %s %s is forbidden, use %s instead.',
+                    $reference['fullyQualifiedName'],
+                    $nameType,
+                    $alternative,
+                ),
+                $reference['pointer'],
+                $code,
+            );
+            if (!$fix) {
+                continue;
+            }
+
+            $phpcsFile->fixer->beginChangeset();
+
+            FixerHelper::change($phpcsFile, $reference['pointer'], $reference['pointer'], $alternative);
+
+            $phpcsFile->fixer->endChangeset();
         }
     }
 
@@ -190,36 +224,54 @@ class ForbiddenClassesSniff implements Sniff
     }
 
     /**
-     * @return array{fullyQualifiedName: string, startPointer: int|null, endPointer: int|null}[]
+     * @return list<array{fullyQualifiedName: string, pointer: int}>
      */
     private function getAllReferences(File $phpcsFile, int $startPointer, int $endPointer): array
     {
+        $tokens = $phpcsFile->getTokens();
+
         // Always ignore first token
         $startPointer++;
         $references = [];
 
         while ($startPointer < $endPointer) {
-            $nextComma = TokenHelper::findNext($phpcsFile, [T_COMMA], $startPointer + 1);
-            $nextSeparator = min($endPointer, $nextComma ?? PHP_INT_MAX);
-            $reference = ReferencedNameHelper::getReferenceName($phpcsFile, $startPointer, $nextSeparator - 1);
+            $referencePointer = TokenHelper::findNext(
+                $phpcsFile,
+                [...TokenHelper::CLASS_KEYWORD_CODES, ...TokenHelper::NAME_TOKEN_CODES],
+                $startPointer,
+            );
+
+            if ($referencePointer === null) {
+                break;
+            }
+
+            if (in_array($tokens[$referencePointer]['code'], TokenHelper::CLASS_KEYWORD_CODES, true)) {
+                $startPointer = $referencePointer + 1;
+                continue;
+            }
+
+            $reference = $tokens[$referencePointer]['content'];
 
             if (
-                empty($reference) === false
+                strlen($reference) !== 0
                 && !in_array(strtolower($reference), self::$keywordReferences, true)
             ) {
                 $references[] = [
                     'fullyQualifiedName' => NamespaceHelper::resolveClassName($phpcsFile, $reference, $startPointer),
-                    'startPointer' => TokenHelper::findNextEffective($phpcsFile, $startPointer, $endPointer),
-                    'endPointer' => TokenHelper::findPreviousEffective($phpcsFile, $nextSeparator - 1, $startPointer),
+                    'pointer' => $referencePointer,
                 ];
             }
 
-            $startPointer = $nextSeparator + 1;
+            $startPointer = $referencePointer + 1;
         }
 
         return $references;
     }
 
+    /**
+     * @param array<string, (string|null)> $option
+     * @return array<string, (string|null)>
+     */
     private static function normalizeInputOption(array $option): array
     {
         $forbiddenClasses = [];
@@ -230,76 +282,21 @@ class ForbiddenClassesSniff implements Sniff
         return $forbiddenClasses;
     }
 
-    private static function normalizeClassName(string|null $typeName): string|null
+    private static function normalizeClassName(?string $typeName): ?string
     {
-        if (empty($typeName) === true || strtolower($typeName) === 'null') {
+        if ($typeName === null || strlen($typeName) === 0 || strtolower($typeName) === 'null') {
             return null;
         }
 
         return NamespaceHelper::getFullyQualifiedTypeName($typeName);
     }
 
-    private function addErrorWithoutFixing(
-        File $phpcsFile,
-        array $reference,
-        string $nameType,
-        string|null $alternative,
-        string $code
-    ): void {
-        if ($alternative === null) {
-            $phpcsFile->addError(
-                sprintf('Usage of %s %s is forbidden.', $reference['fullyQualifiedName'], $nameType),
-                $reference['startPointer'],
-                $code
-            );
+    private function formatAlternativesArray(string $alternativesString): array
+    {
+        $alternativesString = str_replace(' ', '', $alternativesString);
+        $alternatives = explode(',', $alternativesString);
+        $alternatives = array_map(static fn($alt) => self::normalizeClassName($alt), array_filter($alternatives));
 
-            return;
-        }
-
-        $alternatives = array_map('trim', explode(',', $alternative));
-        $phpcsFile->addError(
-            sprintf(
-                count($alternatives) === 1
-                    ? 'Usage of %s %s is forbidden, use %s instead.'
-                    : 'Usage of %s %s is forbidden, use one of these instead: %s.',
-                $reference['fullyQualifiedName'],
-                $nameType,
-                implode(', \\', $alternatives)
-            ),
-            $reference['startPointer'],
-            $code
-        );
-    }
-
-    private function addErrorAndFix(
-        File $phpcsFile,
-        array $reference,
-        string $nameType,
-        string $alternative,
-        string $code
-    ): void {
-        $fix = $phpcsFile->addFixableError(
-            sprintf(
-                'Usage of %s %s is forbidden, use %s instead.',
-                $reference['fullyQualifiedName'],
-                $nameType,
-                $alternative
-            ),
-            $reference['startPointer'],
-            $code
-        );
-
-        if (!$fix) {
-            return;
-        }
-
-        $phpcsFile->fixer->beginChangeset();
-        $phpcsFile->fixer->replaceToken($reference['startPointer'], $alternative);
-        FixerHelper::removeBetweenIncluding(
-            $phpcsFile,
-            $reference['startPointer'] + 1,
-            $reference['endPointer']
-        );
-        $phpcsFile->fixer->endChangeset();
+        return array_merge([''], $alternatives);
     }
 }

--- a/OpaySniffs/ruleset.xml
+++ b/OpaySniffs/ruleset.xml
@@ -172,9 +172,8 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat">
         <properties>
-            <property name="withSpaces" value="no"/>
             <property name="shortNullable" value="no"/>
             <property name="nullPosition" value="last"/>
         </properties>
@@ -183,14 +182,4 @@
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
     <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
-    <rule ref="MoxioSniffs.PHP.DisallowArrayCombinersWithSingleArray"/>
-    <rule ref="MoxioSniffs.PHP.DisallowBareContinueInSwitch"/>
-    <rule ref="MoxioSniffs.PHP.DisallowDateTime"/>
-    <rule ref="MoxioSniffs.PHP.DisallowImplicitIteratorToArrayWithUseKeys"/>
-    <rule ref="MoxioSniffs.PHP.DisallowImplicitLooseBase64Decode"/>
-    <rule ref="MoxioSniffs.PHP.DisallowImplicitLooseComparison"/>
-    <rule ref="MoxioSniffs.PHP.DisallowImplicitMicrotimeAsString"/>
-    <rule ref="MoxioSniffs.PHP.DisallowMbDetectEncoding"/>
-    <rule ref="MoxioSniffs.PHP.DisallowUniqidWithoutMoreEntropy"/>
-    <rule ref="MoxioSniffs.PHP.DisallowUtf8EncodeDecode"/>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Package content
 - <a target="_blank" href="https://github.com/FriendsOfPHP/PHP-CS-Fixer">friendsofphp/php-cs-fixer</a> - Powerful PHP Coding Standards tool
 - <a target="_blank" href="https://github.com/squizlabs/PHP_CodeSniffer">squizlabs/php_codesniffer</a> - Another powerful and customizable PHP Coding Standards tool
 - <a target="_blank" href="https://github.com/slevomat/coding-standard">slevomat/coding-standard</a> - Set of additional linting rules for PHP CodeSniffer
-- <a target="_blank" href="https://github.com/Moxio/php-codesniffer-sniffs">moxio/php-codesniffer-sniffs</a> - Set of additional linting rules for PHP CodeSniffer
 - Custom Opay linting rules for PHP CodeSniffer
 
 `PHP-CS-Fixer` and `PHP_CodeSniffer` are both PHP code linting tools that complement each other allowing developers to write the highest quality code.

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,9 @@
     }],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.75",
-        "moxio/php-codesniffer-sniffs": "^2.6",
-        "slevomat/coding-standard": "^8.15",
-        "squizlabs/php_codesniffer": "^3.7"
+        "friendsofphp/php-cs-fixer": "^3.91",
+        "slevomat/coding-standard": "^8.25",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  linting_tools:
+    image: ${DOCKER_IMAGE:-php:8.5-fpm-alpine}
+    tty: true
+    user: "1000"
+    restart: "no"
+    ports:
+      - "127.0.0.1:8997:80"
+    volumes:
+      - .:/app
+    working_dir: /app
+    container_name: linting_tools
+    networks:
+      - localstack
+
+networks:
+  localstack:
+    name: localstack
+    external: true

--- a/lint
+++ b/lint
@@ -2,23 +2,23 @@
 
 if [ -z "$1" ]; then
 
-    vendor/bin/php-cs-fixer fix . --dry-run --verbose --allow-unsupported-php-version=yes
+    vendor/bin/php-cs-fixer fix . --dry-run --verbose
     vendor/bin/phpcs -p --standard=OpaySniffs . --ignore=./vendor
 
 elif [ "$1" == "fix" ]; then
 
-    vendor/bin/php-cs-fixer fix . --verbose --allow-unsupported-php-version=yes
+    vendor/bin/php-cs-fixer fix . --verbose
     vendor/bin/phpcbf -p --standard=OpaySniffs . --ignore=./vendor
 
 elif [ "$1" == "--custom" ] && [ -z "$2" ]; then
 
-    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --dry-run --verbose --allow-unsupported-php-version=yes
-    vendor/bin/phpcs -p --standard="Examples/custom_phpcs_config.xml"
+    vendor/bin/php-cs-fixer fix --config="ConfigExamples/custom_phpcsfixer_config.php" --dry-run --verbose
+    vendor/bin/phpcs -p --standard="ConfigExamples/custom_phpcs_config.xml"
 
 elif [ "$1" == "--custom" ] && [ "$2" == "fix" ]; then
 
-    vendor/bin/php-cs-fixer fix --config="Examples/custom_phpcsfixer_config.php" --verbose --allow-unsupported-php-version=yes
-    vendor/bin/phpcbf -p --standard="Examples/custom_phpcs_config.xml"
+    vendor/bin/php-cs-fixer fix --config="ConfigExamples/custom_phpcsfixer_config.php" --verbose
+    vendor/bin/phpcbf -p --standard="ConfigExamples/custom_phpcs_config.xml"
 
 else
 


### PR DESCRIPTION
## Description

1. Remove `moxio/php-codesniffer-sniffs`.
    - It looks like it is not maintained anymore, last update was 18 months ago and it conflicts with `squizlabs/php_codesniffer` and `slevomat/coding-standard`.
2. Remove all Moxio rules. Would be nice to replace them with something else, but, from what I see, they were not very critical.
3. Update all other dependencies to newest versions compatible with PHP 8.5.
4. Replace deprecated `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat` with `SlevomatCodingStandard.TypeHints.DNFTypeHintFormat`.
5. Refactor `OpaySniffs/Sniffs/Classes/ForbiddenClassesSniff.php` due to deprecated functions used in previous versions:
    - Copy original `ForbiddenClassesSniff` ignoring all changes in previous Opay version.
    - Do only required changes without full class refactoring.
    - Screenshot of working Sniff added below.
6. Add `docker-compose.yml` and `Makefile` to allow running `composer install` inside of container instead of having PHP on localhost.
    - Adding `.env` with config `DOCKER_IMAGE: ghcr.io/opay/base-php-local:8.5` allows using internal docker image, otherwise composer must be installed alongside with default `php:8.5-fpm-alpine`.
7. Fix `lint` command
    - Wrong Examples directory path
    - Useless `allow-unsupported-php-version` command (probably, it was useful before upgrade)
8. Upgrade PHP version to 8.5 in GitHub linting workflow

❗ **New tag should be `v1.6.0` or even `v2.0.0`, since this upgrade contains Moxio deprecation.**

<img width="1380" height="345" alt="image" src="https://github.com/user-attachments/assets/8393d6d3-0194-4526-a762-8b1fd116c0ef" />

## Type of change
- [ ] __New feature__ (non-breaking change which adds functionality)
- [x] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected)
- [x] __Bug fix__ (non-breaking change which fixes an issue)
- [x] __Tech. debt__ (non-breaking code improvement or technical functionality)

## Code testing
- [x] Manual testing done

## Code quality
- [x] My changes generate no new warnings or errors in IDE
- [x] I have performed a self-review of my own code before selecting reviewers
- [x] My code does not smell (I am sure about my code quality, I did the best I could)
