### PR TITLE
PM-264: fix redundant line rule

### DIFF
--- a/OpaySniffs/Sniffs/Files/RedundantEmptyLinesSniff.php
+++ b/OpaySniffs/Sniffs/Files/RedundantEmptyLinesSniff.php
@@ -9,8 +9,6 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class RedundantEmptyLinesSniff implements Sniff
 {
-    private array $errorsOnLines = [];
-
     public function register(): array
     {
         return [T_OPEN_TAG];
@@ -22,6 +20,7 @@ class RedundantEmptyLinesSniff implements Sniff
         $file = file($phpcsFile->getFilename());
 
         $lastLineContent = null;
+        $errorsOnLines = [];
 
         $tokens = $phpcsFile->getTokens();
         foreach ($tokens as $key => $token) {
@@ -38,12 +37,12 @@ class RedundantEmptyLinesSniff implements Sniff
                 continue;
             }
 
-            if ($token['column'] !== 1 || array_key_exists($line, $this->errorsOnLines)) {
+            if ($token['column'] !== 1 || array_key_exists($line, $errorsOnLines)) {
                 continue;
             }
 
             if (empty($content) && empty($lastLineContent)) {
-                $this->errorsOnLines[$line] = true;
+                $errorsOnLines[$line] = true;
 
                 $phpcsFile->addError(
                     'Redundant empty line found.',


### PR DESCRIPTION
## Description

Can not think why lines should be kept between different files ans it has no method to read private property. Array can be local variable. This solves issue with payment-api linting bug.

## Type of change
- [ ] __New feature__ (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected)
- [ ] __Bug fix__ (non-breaking change which fixes an issue)
- [ ] __Tech. debt__ (non-breaking code improvement or technical functionality)

## Code testing
- [ ] Manual testing done

## Code quality
- [ ] My changes generate no new warnings or errors in IDE
- [ ] I have performed a self-review of my own code before selecting reviewers
- [ ] My code does not smell (I am sure about my code quality, I did the best I could)
